### PR TITLE
Fixed spelling of "Assured" in footer

### DIFF
--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -1,4 +1,4 @@
-REST Assuerd is [open source]({{ site.source_link }})
+REST Assured is [open source]({{ site.source_link }})
 &mdash;
 Issue [tracker](https://github.com/rest-assured/rest-assured/issues)
 &mdash;


### PR DESCRIPTION
Assuerd --> Assured

I know this is a large pull request so please take your time.